### PR TITLE
Update URL for Library Manager submission instructions

### DIFF
--- a/client/src/components/explanation/doesnotexist.js
+++ b/client/src/components/explanation/doesnotexist.js
@@ -17,7 +17,7 @@ function DoesNotExist (props) {
                 <p>
                     There might be a typo in the library name, version, or the library
                     might not be published yet. If you want to add your own library 
-                    to Library Manager, follow <a href="https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ#how-can-i-add-my-library-to-library-manager">these instructions</a>
+                    to Library Manager, follow <a href="https://github.com/arduino/library-registry#adding-a-library-to-library-manager">these instructions</a>
                 </p>
 
                 <NavLink to="/">
@@ -39,7 +39,7 @@ function DoesNotExist (props) {
                 <p>
                     There might be a typo in the library name or the library
                     might not be published yet. If you want to add your own library 
-                    to Library Manager, follow <a href="https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ#how-can-i-add-my-library-to-library-manager">these instructions</a>
+                    to Library Manager, follow <a href="https://github.com/arduino/library-registry#adding-a-library-to-library-manager">these instructions</a>
                 </p>
 
                 <NavLink to="/">


### PR DESCRIPTION
[Arduino has created](https://blog.arduino.cc/2021/06/07/new-workflow-for-arduino-library-submissions/) a dedicated repository for Library Manager submissions and moved the documentation there. The content of the page pointed to by the previous URL was replaced by a link pointing to the new Library Manager FAQ, so the user will still find the information after a few clicks, but it will be a better experience for them to be able to get to the instructions with a single click.